### PR TITLE
Hacky fix for wonky safari elapsed output

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -42,7 +42,7 @@ typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds
 
 inline TimePoint now() {
   return std::chrono::duration_cast<std::chrono::milliseconds>
-        (std::chrono::steady_clock::now().time_since_epoch()).count();
+        (std::chrono::system_clock::now().time_since_epoch()).count();
 }
 
 template<class Entry, int Size>


### PR DESCRIPTION
Inside a webworker, safari's steady_clock output
is wrong, and sometimes negative. This is likely
an emscripten bug, and the issue only occurs when
stockfish is run inside a service worker.