### PR TITLE
Instruction to install uglifyjs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,8 @@ About 1MB uncompressed, 220 KB gzipped.
 Building
 --------
 
-[Install Emscripten](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html),
+[Install Emscripten](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html) and 
+[uglifyjs](https://github.com/mishoo/UglifyJS2),
 then:
 
 ```


### PR DESCRIPTION
The build.js [calls uglifyjs](https://github.com/niklasf/stockfish.js/blob/b0bced9e0597f3aba7c41ab1147d880edfe7f255/build.sh#L10), so I added this requirement in Readme.