### PR TITLE
remove --user option from docker run in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ then:
 Or using Docker:
 
 ```
-docker run --volume $PWD:/home/builder/stockfish.js --user $(id -u) niklasf/emscripten-for-stockfish
+docker run --volume $PWD:/home/builder/stockfish.js niklasf/emscripten-for-stockfish
 ```
 
 Usage


### PR DESCRIPTION
Fix for issue https://github.com/niklasf/stockfish.js/issues/8

based on docker documentaion, not specifying --user runs it as root.

https://docs.docker.com/engine/reference/run/#user
